### PR TITLE
Fix middleware match 

### DIFF
--- a/lib/src/router/handler.dart
+++ b/lib/src/router/handler.dart
@@ -47,14 +47,14 @@ abstract class RouteHandler {
 
     ReqRes result = reqRes;
     bool canGotoNext = false;
-    await handler(request, reqRes.res, ([nr_]) {
-      if (nr_ != null && nr_ is! Request && nr_ is! Response) {
+    await handler(request, reqRes.res, ([nextFn]) {
+      if (nextFn != null && nextFn is! Request && nextFn is! Response) {
         throw PharaohException.value(
             'Next Function result can only be Request or Response');
       }
 
-      if (nr_ is Request) result = (req: nr_, res: reqRes.res);
-      if (nr_ is Response) result = (req: reqRes.req, res: nr_);
+      if (nextFn is Request) result = (req: nextFn, res: reqRes.res);
+      if (nextFn is Response) result = (req: reqRes.req, res: nextFn);
       canGotoNext = true;
     });
 

--- a/lib/src/router/route.dart
+++ b/lib/src/router/route.dart
@@ -6,6 +6,9 @@ import '../utils/exceptions.dart';
 import 'handler.dart';
 import 'router.dart';
 
+// ignore: constant_identifier_names
+const ANY_PATH = '/:route(.*)';
+
 String verbString(List<HTTPMethod> verbs) => verbs.map((e) => e.name).join(':');
 
 typedef RouteResult = ({bool hasMatch, Map<String, String> params});
@@ -35,7 +38,7 @@ class Route {
   /// Any path with the following methods [HTTPMethod]
   Route.path(String p, [HTTPMethod method = HTTPMethod.ALL])
       : verbs = [method],
-        path = '/:route(.*)',
+        path = ANY_PATH,
         prefix = p;
 
   Route withPrefix(String prefix) => Route(

--- a/lib/src/router/router.dart
+++ b/lib/src/router/router.dart
@@ -1,12 +1,8 @@
-// ignore_for_file: constant_identifier_names
-
 import 'dart:async';
 
 import '../http/request.dart';
 import 'handler.dart';
 import 'route.dart';
-
-const ANY_PATH = '*';
 
 const BASE_PATH = '/';
 

--- a/pharaoh_examples/lib/route_groups/index.dart
+++ b/pharaoh_examples/lib/route_groups/index.dart
@@ -9,6 +9,7 @@ void main() async {
     ..put('/yoo', (req, res) => res.json({"pookey": "reyrey"}));
 
   final adminRouter = app.router()
+    ..use(logRequests)
     ..get('/user', (req, res) => res.json({"chima": "happy"}))
     ..put('/hello', (req, res) => res.json({"name": "chima"}))
     ..post('/say-hello', (req, res) => res.notFound())

--- a/pharaoh_examples/pubspec.yaml
+++ b/pharaoh_examples/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   shelf_cors_headers: ^0.1.5
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0
   test: ^1.21.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.2
 repository: https://github.com/codekeyz/pharaoh
 
 environment:
-  sdk: ^3.1.5
+  sdk: ^3.2.0
 
 dependencies:
   meta: ^1.11.0
@@ -17,7 +17,7 @@ dependencies:
   shelf: ^1.4.1
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0
   test: ^1.21.0
   supertest:
     path: ./supertest


### PR DESCRIPTION
Fixed middleware not being executed in groups.

```dart
import 'package:pharaoh/pharaoh.dart';

final app = Pharaoh();

void main() async {
  final guestRouter = app.router()
    ..use(logRequests) // this should only log for routes in this router
    ..get('/foo', (req, res) => res.ok("Hello World"))
    ..post('/bar', (req, res) => res.json({"mee": "moo"}))
    ..put('/yoo', (req, res) => res.json({"pookey": "reyrey"}));

  app.group('/guest', guestRouter);

  app.get('/', (req, res) => res.json('Foo Bar'));

  await app.listen();
}

```
