### PR TITLE
chaining should terminate if response ended

### DIFF
--- a/packages/pharaoh/lib/src/router/handler.dart
+++ b/packages/pharaoh/lib/src/router/handler.dart
@@ -88,7 +88,7 @@ abstract class RouteHandler {
           result = result.merge(nr_);
           canGotoNext = true;
 
-          if (chain == null) {
+          if (chain == null || result.res.ended) {
             _streamCtrl.close();
           } else {
             _streamCtrl.add(chain);

--- a/packages/pharaoh/test/router/handler_test.dart
+++ b/packages/pharaoh/test/router/handler_test.dart
@@ -112,11 +112,9 @@ void main() {
 
       listResultList.clear();
 
-      final shortLivedChain = testChain3.chain(
-        (req, res, next) {
-          next(res.end());
-        },
-      ).chain(testChain2);
+      final shortLivedChain = testChain3
+          .chain((req, res, next) => next(res.end()))
+          .chain(testChain2);
 
       await (await request(getApp(shortLivedChain))).get('/test').test();
       expect(listResultList, [3, 1, 3, 2, 1]);

--- a/packages/pharaoh/test/router/handler_test.dart
+++ b/packages/pharaoh/test/router/handler_test.dart
@@ -80,7 +80,7 @@ void main() {
 
       final HandlerFunc mdw3 = (req, res, next) {
         listResultList.add(3);
-        next(res.end());
+        next();
       };
 
       Pharaoh getApp(HandlerFunc chain) {
@@ -109,6 +109,17 @@ void main() {
       final complexChain = testChain3.chain(testChain1).chain(testChain2);
       await (await request(getApp(complexChain))).get('/test').test();
       expect(listResultList, [3, 1, 3, 2, 1, 1, 2, 3, 2, 1, 3]);
+
+      listResultList.clear();
+
+      final shortLivedChain = testChain3.chain(
+        (req, res, next) {
+          next(res.end());
+        },
+      ).chain(testChain2);
+
+      await (await request(getApp(shortLivedChain))).get('/test').test();
+      expect(listResultList, [3, 1, 3, 2, 1]);
     });
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

I noticed middleware chaining continued even if the response ended.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
