### PR TITLE
bugfix: capture remaining parts of route as parametric route

### DIFF
--- a/packages/spanner/lib/src/tree/tree.dart
+++ b/packages/spanner/lib/src/tree/tree.dart
@@ -221,8 +221,6 @@ class Spanner {
 
         devlog('- Finding Defn for $routePart        -> terminal?    $isLastPart');
 
-        print('Finding matching for $routePart');
-
         final definition = parametricNode.findMatchingDefinition(
           method,
           routePart,

--- a/packages/spanner/test/parametric_test.dart
+++ b/packages/spanner/test/parametric_test.dart
@@ -24,24 +24,19 @@ void main() {
       });
 
       test('close door parameter definitions', () {
-        router() =>
-            Spanner()..on(HTTPMethod.GET, '/user/<userId><keyId>', okHdler);
+        router() => Spanner()..on(HTTPMethod.GET, '/user/<userId><keyId>', okHdler);
 
         final exception = runSyncAndReturnException<ArgumentError>(router);
-        expect(
-            exception.message,
-            contains(
-                'Parameter definition is not valid. Close door neighbors'));
+        expect(exception.message,
+            contains('Parameter definition is not valid. Close door neighbors'));
         expect(exception.invalidValue, '<userId><keyId>');
       });
 
       test('invalid parameter definition', () {
-        router() => Spanner()
-          ..on(HTTPMethod.GET, '/user/<userId#@#.XDkd@#>>#>', okHdler);
+        router() => Spanner()..on(HTTPMethod.GET, '/user/<userId#@#.XDkd@#>>#>', okHdler);
 
         final exception = runSyncAndReturnException<ArgumentError>(router);
-        expect(
-            exception.message, contains('Parameter definition is not valid'));
+        expect(exception.message, contains('Parameter definition is not valid'));
         expect(exception.invalidValue, '<userId#@#.XDkd@#>>#>');
       });
     });
@@ -77,9 +72,7 @@ void main() {
 
       node = router.lookup(HTTPMethod.GET, '/user/aws-image.png/A29384/hello');
       expect(
-          node,
-          havingParameters<StaticNode>(
-              {'file': 'aws-image', 'user2': 'A29384'}));
+          node, havingParameters<StaticNode>({'file': 'aws-image', 'user2': 'A29384'}));
 
       node = router.lookup(HTTPMethod.GET, '/a/param-static');
       expect(node, havingParameters<ParameterDefinition>({'param': 'param'}));
@@ -101,6 +94,20 @@ void main() {
       expect(
         router.lookup(HTTPMethod.GET, '/fr/item/12345/edit'),
         havingParameters({'lang': 'fr', '*': '12345/edit'}),
+      );
+    });
+
+    test('should capture remaining parts as parameter when no wildcard', () {
+      final router = Spanner()..on(HTTPMethod.GET, '/<lang>/item/<id>', okHdler);
+
+      expect(
+        router.lookup(HTTPMethod.GET, '/fr/item/12345'),
+        havingParameters({'lang': 'fr', 'id': '12345'}),
+      );
+
+      expect(
+        router.lookup(HTTPMethod.GET, '/fr/item/12345/edit'),
+        havingParameters({'lang': 'fr', 'id': '12345/edit'}),
       );
     });
   });

--- a/pharaoh_examples/lib/serve_files_1/index.dart
+++ b/pharaoh_examples/lib/serve_files_1/index.dart
@@ -19,9 +19,8 @@ void main() async {
 
   /// /files/* is accessed via req.params[0]
   /// but here we name it :file
-  app.get('/files/:file(.*)', (req, res) async {
+  app.get('/files/<file>', (req, res) async {
     final pathToFile = req.params['file'];
-
     final file = File('$publicDir/files/$pathToFile');
     final exists = await file.exists();
     if (!exists) {

--- a/pharaoh_examples/lib/serve_files_1/index.dart
+++ b/pharaoh_examples/lib/serve_files_1/index.dart
@@ -17,8 +17,8 @@ void main() async {
     return res.type(ContentType.html).send(file.openRead());
   });
 
-  /// /files/* is accessed via req.params[0]
-  /// but here we name it :file
+  /// /files/* is accessed via req.params[*]
+  /// but here we name it <file>
   app.get('/files/<file>', (req, res) async {
     final pathToFile = req.params['file'];
     final file = File('$publicDir/files/$pathToFile');


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

I just realized`Spanner` returns null when you try to lookup this route `/files/notes/groceries.txt` in the Trie.
 
```dart
 /// /files/* is accessed via req.params[*]
  /// but here we name it <file>
  app.get('/files/<file>', (req, res) async {
    final pathToFile = req.params['file'];
    final file = File('$publicDir/files/$pathToFile');
    final exists = await file.exists();
    if (!exists) {
      return res.status(404).send('"Cant find that file, sorry!"');
    }

    return res.send(file.openRead());
  });
```

Spanner is able to find the static node for `file`, then expects to find another static node `notes`. But in this case, `file` node has no wildcard note but a parametric node that has just one definition.

The good fix is to always capture the remaining part of a route as a parameter if there is no wildcard node and the current node is parametric and has one definition that is not composite.


#### Test to validate the fix 

```dart
test('should capture remaining parts as parameter when no wildcard', () {
      final router = Spanner()..on(HTTPMethod.GET, '/<lang>/item/<id>', okHdler);

      expect(
        router.lookup(HTTPMethod.GET, '/fr/item/12345'),
        havingParameters({'lang': 'fr', 'id': '12345'}),
      );

      expect(
        router.lookup(HTTPMethod.GET, '/fr/item/12345/edit'),
        havingParameters({'lang': 'fr', 'id': '12345/edit'}),
      );
});
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
