### PR TITLE
feat: use application/json & jsonEncode body as default for spookie.post

### DIFF
--- a/packages/pharaoh/test/router/router_group_test.dart
+++ b/packages/pharaoh/test/router/router_group_test.dart
@@ -1,27 +1,25 @@
-import 'dart:convert';
-
 import 'package:pharaoh/pharaoh.dart';
 import 'package:spookie/spookie.dart';
 
 void main() {
   group('router', () {
     test('should execute middlewares in group', () async {
-      final app = Pharaoh()..post('/', (req, res) => res.ok(req.body));
+      final app = Pharaoh()..post('/', (req, res) => res.json(req.body));
 
-      final adminRouter = app
-        ..router().get('/', (req, res) => res.ok('Holy Moly 🚀'))
-        ..post('/hello', (req, res) => res.ok(req.body));
+      final adminRouter = app.router()
+        ..get('/', (req, res) => res.ok('Holy Moly 🚀'))
+        ..post('/hello', (req, res) => res.json(req.body));
       app.group('/admin', adminRouter);
 
       await (await request(app))
-          .post('/', jsonEncode({'_': 'Hello World 🚀'}))
-          .expectBody('{"_":"Hello World 🚀"}')
+          .post('/', {'_': 'Hello World 🚀'})
+          .expectBody({"_": "Hello World 🚀"})
           .expectStatus(200)
           .test();
 
       await (await request(app))
-          .post('/admin/hello', jsonEncode({'_': 'Hello World 🚀'}))
-          .expectBody('{"_":"Hello World 🚀"}')
+          .post('/admin/hello', {'_': 'Hello World 🚀'})
+          .expectBody({"_": "Hello World 🚀"})
           .expectStatus(200)
           .test();
 

--- a/packages/spookie/lib/spookie.dart
+++ b/packages/spookie/lib/spookie.dart
@@ -71,11 +71,16 @@ class _$SpookieImpl extends Spookie {
     String path,
     Object? body, {
     Map<String, String>? headers,
-  }) =>
-      expectHttp(
-        http.post(getUri(path),
-            headers: mergeHeaders(headers ?? {}), body: body),
-      );
+  }) {
+    headers = mergeHeaders(headers ?? {});
+
+    if (body is Map && !headers.containsKey(HttpHeaders.contentTypeHeader)) {
+      headers[HttpHeaders.contentTypeHeader] = 'application/json';
+      body = jsonEncode(body);
+    }
+
+    return expectHttp(http.post(getUri(path), headers: headers, body: body));
+  }
 
   @override
   HttpResponseExpection get(
@@ -93,8 +98,7 @@ class _$SpookieImpl extends Spookie {
     Object? body,
   }) =>
       expectHttp(
-        http.delete(getUri(path),
-            headers: mergeHeaders(headers ?? {}), body: body),
+        http.delete(getUri(path), headers: mergeHeaders(headers ?? {}), body: body),
       );
 
   @override
@@ -104,8 +108,7 @@ class _$SpookieImpl extends Spookie {
     Object? body,
   }) =>
       expectHttp(
-        http.patch(getUri(path),
-            headers: mergeHeaders(headers ?? {}), body: body),
+        http.patch(getUri(path), headers: mergeHeaders(headers ?? {}), body: body),
       );
 
   @override
@@ -115,8 +118,7 @@ class _$SpookieImpl extends Spookie {
     Object? body,
   }) =>
       expectHttp(
-        http.put(getUri(path),
-            headers: mergeHeaders(headers ?? {}), body: body),
+        http.put(getUri(path), headers: mergeHeaders(headers ?? {}), body: body),
       );
 
   @override

--- a/packages/spookie/lib/src/http_expectation.dart
+++ b/packages/spookie/lib/src/http_expectation.dart
@@ -15,24 +15,20 @@ typedef GetValueFromResponse<T> = T Function(http.Response response);
 
 typedef MatchCase = ({GetValueFromResponse value, dynamic matcher});
 
-class HttpResponseExpection
-    extends ExpectationBase<HttpFutureResponse, http.Response> {
+class HttpResponseExpection extends ExpectationBase<HttpFutureResponse, http.Response> {
   HttpResponseExpection(super.value);
 
   final List<MatchCase> _matchcases = [];
 
   HttpResponseExpection expectHeader(String header, dynamic matcher) {
-    final MatchCase test =
-        (value: (resp) => resp.headers[header], matcher: matcher);
+    final MatchCase test = (value: (resp) => resp.headers[header], matcher: matcher);
     _matchcases.add(test);
     return this;
   }
 
   HttpResponseExpection expectContentType(dynamic matcher) {
-    final MatchCase test = (
-      value: (resp) => resp.headers[HttpHeaders.contentTypeHeader],
-      matcher: matcher
-    );
+    final MatchCase test =
+        (value: (resp) => resp.headers[HttpHeaders.contentTypeHeader], matcher: matcher);
     _matchcases.add(test);
     return this;
   }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

No need to jsonEncode the data when you're calling `spooke.post`. It'll automatically encode it and set the `application/json` header in a post request

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
