### PR TITLE
feat: Allow passing uri directly to Spookie

### DIFF
--- a/packages/spookie/lib/spookie.dart
+++ b/packages/spookie/lib/spookie.dart
@@ -8,10 +8,10 @@ export 'package:test/test.dart';
 typedef HttpRequestHandler = Function(HttpRequest req);
 
 abstract interface class Spookie {
-  factory Spookie.fromServer(HttpServer server) =>
+  factory Spookie.server(HttpServer server) =>
       _$SpookieImpl(getServerUri(server));
 
-  factory Spookie.fromUri(Uri uri) => _$SpookieImpl(uri);
+  factory Spookie.uri(Uri uri) => _$SpookieImpl(uri);
 
   Spookie auth(String user, String pass);
 
@@ -151,7 +151,7 @@ class SpookieAgent {
 
     _server = await HttpServer.bind(InternetAddress.anyIPv4, 0)
       ..listen(app);
-    return _instance = Spookie.fromServer(_server!);
+    return _instance = Spookie.server(_server!);
   }
 }
 

--- a/packages/spookie/test/spookie_test.dart
+++ b/packages/spookie/test/spookie_test.dart
@@ -18,12 +18,17 @@ void main() {
 
       test('should work with an active server', () async {
         final app = Pharaoh()
-          ..post('/hello', (req, res) => res.ok('Hello World'));
-        await (await (request<Pharaoh>(app))).get('/').expectStatus(404).test();
-        await (await (request<Pharaoh>(app)))
+          ..post('/hello', (req, res) => res.ok('Active Server'));
+
+        await app.listen(port: 5050);
+
+        await Spookie.fromUri(app.uri)
             .post('/hello', {})
+            .expectBody('Active Server')
             .expectStatus(200)
             .test();
+
+        await app.shutdown();
       });
 
       test('should work with remote server', () async {

--- a/packages/spookie/test/spookie_test.dart
+++ b/packages/spookie/test/spookie_test.dart
@@ -22,7 +22,7 @@ void main() {
 
         await app.listen(port: 5050);
 
-        await Spookie.fromUri(app.uri)
+        await Spookie.uri(app.uri)
             .post('/hello', {})
             .expectBody('Active Server')
             .expectStatus(200)


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Resolves: #110 

We should be able to pass a URI directly to `Spookie`.

```dart
    await Spookie.uri(Uri(scheme: 'http', host: 'localhost', port: 5000))
            .post('/hello', {})
            .expectBody('Active Server')
            .expectStatus(200)
            .test();
```

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
